### PR TITLE
Upgrading the Google Shopping plugin by specifying the required product categories

### DIFF
--- a/Nop.Plugin.Feed.GoogleShopping/GoogleShoppingSettings.cs
+++ b/Nop.Plugin.Feed.GoogleShopping/GoogleShoppingSettings.cs
@@ -1,4 +1,4 @@
-﻿using Nop.Core.Configuration;
+using Nop.Core.Configuration;
 
 namespace Nop.Plugin.Feed.GoogleShopping
 {
@@ -47,5 +47,8 @@ namespace Nop.Plugin.Feed.GoogleShopping
         /// Number of days for expiration date
         /// </summary>
         public int ExpirationNumberOfDays { get; set; }
+
+
+        public string SelectedCategoryIds { get; set; }
     }
 }

--- a/Nop.Plugin.Feed.GoogleShopping/Views/_Configure.General.cshtml
+++ b/Nop.Plugin.Feed.GoogleShopping/Views/_Configure.General.cshtml
@@ -1,4 +1,4 @@
-﻿@model Nop.Plugin.Feed.GoogleShopping.Models.FeedGoogleShoppingModel
+@model Nop.Plugin.Feed.GoogleShopping.Models.FeedGoogleShoppingModel
 
 <div class="panel-group">
     <div class="panel panel-default">
@@ -65,6 +65,34 @@
                 <div class="col-md-9">
                     <nop-select asp-for="DefaultGoogleCategory" asp-items="Model.AvailableGoogleCategories" />
                     <span asp-validation-for="DefaultGoogleCategory"></span>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="col-md-3">
+                    <nop-label asp-for="SelectedCategoryIds" />
+                </div>
+                <div class="col-md-9">
+                    <nop-select asp-for="SelectedCategoryIds" asp-items="Model.AvailableCategories" asp-multiple="true" />
+                    <script>
+                                $(document).ready(function () {
+                                    var categorysIdsInput = $('#@Html.IdFor(model => model.SelectedCategoryIds)').data("kendoMultiSelect");
+                                    categorysIdsInput.setOptions({
+                                        autoClose: false
+                                    });
+
+                                    @if (Model.AvailableStores.Count == 0)
+                            {
+                                <text>
+                                    categorysIdsInput.setOptions({
+                                        enable: false
+                                        placeholder: '@T("admin.catalog.products.categories.nocategoriesavailable")'
+                                });
+                                categorysIdsInput._placeholder();
+                                categorysIdsInput._enable();
+                                </text>
+                            }
+                                });
+                    </script>
                 </div>
             </div>
             @if (Model.GeneratedFiles.Count > 0)


### PR DESCRIPTION
Instead of generating the whole website products for Google Shopping feed, we now able to choose our products by selecting the required product categories.