### PR TITLE
Make path compatible with unix systems

### DIFF
--- a/Nop.Plugin.Feed.GoogleShopping/Controllers/FeedGoogleShoppingController.cs
+++ b/Nop.Plugin.Feed.GoogleShopping/Controllers/FeedGoogleShoppingController.cs
@@ -126,7 +126,7 @@ namespace Nop.Plugin.Feed.GoogleShopping.Controllers
             //file paths
             foreach (var store in _storeService.GetAllStores())
             {
-                var localFilePath = System.IO.Path.Combine(_hostingEnvironment.WebRootPath, "files\\exportimport", store.Id + "-" + googleShoppingSettings.StaticFileName);
+                var localFilePath = System.IO.Path.Combine(_hostingEnvironment.WebRootPath, "files", "exportimport", store.Id + "-" + googleShoppingSettings.StaticFileName);
                 if (System.IO.File.Exists(localFilePath))
                     model.GeneratedFiles.Add(new GeneratedFileModel
                     {

--- a/Nop.Plugin.Feed.GoogleShopping/GoogleShoppingService.cs
+++ b/Nop.Plugin.Feed.GoogleShopping/GoogleShoppingService.cs
@@ -695,7 +695,7 @@ namespace Nop.Plugin.Feed.GoogleShopping
             if (store == null)
                 throw new ArgumentNullException(nameof(store));
             
-            var filePath = Path.Combine(_hostingEnvironment.WebRootPath, "files\\exportimport", store.Id + "-" + _googleShoppingSettings.StaticFileName);
+            var filePath = Path.Combine(_hostingEnvironment.WebRootPath, "files", "exportimport", store.Id + "-" + _googleShoppingSettings.StaticFileName);
             using (var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite))
             {
                 GenerateFeed(fs, store);


### PR DESCRIPTION
Fixes a bug where the user is unable to generate a feed when the plugin is running on an unix/linux system